### PR TITLE
Develop / Raspberry Pi Pico W

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -11,6 +11,7 @@ const builtinModules = [
   "spi",
   "uart",
   "rp2",
+  "cyw43_arch",
   "graphics",
   "at",
   "stream",


### PR DESCRIPTION
Include "cyw43_arch" module as one of the builtinModules
Required for https://github.com/kaluma-project/kaluma/pull/517