### PR TITLE
Added "pico_cyw43" module

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -26,6 +26,7 @@ const builtinModules = [
   "vfs_lfs",
   "vfs_fat",
   "sdcard",
+  "pico_cyw43",
 ];
 
 const externals = {};


### PR DESCRIPTION
The bundler doesn't the "pico_cyw43" module as builtinModules, so the webpack process will fail.