### PR TITLE
Normalize some settings

### DIFF
--- a/bin/kaluma.js
+++ b/bin/kaluma.js
@@ -111,7 +111,7 @@ async function findPort(portOrQuery, exit) {
   return port;
 }
 
-program.version('-v, --version', 'output the version number');
+program.version(config.version, '-v, --version', 'output the version number');
 
 program
   .command("shell")

--- a/bin/kaluma.js
+++ b/bin/kaluma.js
@@ -111,7 +111,7 @@ async function findPort(portOrQuery, exit) {
   return port;
 }
 
-program.version(config.version, '-v, --version', 'output the version number');
+program.version('-v, --version', 'output the version number');
 
 program
   .command("shell")

--- a/bin/kaluma.js
+++ b/bin/kaluma.js
@@ -115,7 +115,7 @@ program.version(config.version, '-v, --version', 'output the version number');
 
 program
   .command("shell")
-  .description("[EXPERIMENTAL] shell connect (exit: ctrl+z)")
+  .description("shell connect (exit: ctrl+z)")
   .option("-p, --port <port>", optionDescriptions.port, "@2e8a")
   .action(async function (options) {
     // find port

--- a/bin/kaluma.js
+++ b/bin/kaluma.js
@@ -111,7 +111,7 @@ async function findPort(portOrQuery, exit) {
   return port;
 }
 
-program.version(config.version);
+program.version(config.version, '-v, --version', 'output the version number');
 
 program
   .command("shell")

--- a/bin/kaluma.js
+++ b/bin/kaluma.js
@@ -115,7 +115,7 @@ program.version(config.version, '-v, --version', 'output the version number');
 
 program
   .command("shell")
-  .description("shell connect (exit: ctrl+z)")
+  .description("shell connect (type Ctrl-D to exit)")
   .option("-p, --port <port>", optionDescriptions.port, "@2e8a")
   .action(async function (options) {
     // find port
@@ -128,10 +128,10 @@ program
         console.error(err);
       } else {
         console.log(`connected to ${port}`);
-        console.log(colorName(`To exit: ctrl+z`));
+        console.log(colorName(`Type Ctrl-D to exit`));
         bind(serial, [
           {
-            keycode: 0x1a,
+            keycode: 0x04,
             callback: () => {
               process.exit(0);
             },
@@ -207,10 +207,10 @@ program
       } else {
         console.log(`connected to ${port}`);
         if (options.shell) {
-          console.log(colorName(`To exit: ctrl+z`));
+          console.log(colorName(`Type Ctrl-D to exit`));
           bind(serial, [
             {
-              keycode: 0x1a,
+              keycode: 0x04,
               callback: () => {
                 process.exit(0);
               },

--- a/bin/kaluma.js
+++ b/bin/kaluma.js
@@ -127,7 +127,7 @@ program
       if (err) {
         console.error(err);
       } else {
-        console.log(`connected to ${port}`);
+        console.log(`Connected to ${port}`);
         console.log(colorName(`Type Ctrl-D to exit`));
         bind(serial, [
           {
@@ -205,7 +205,7 @@ program
       if (err) {
         console.error(err);
       } else {
-        console.log(`connected to ${port}`);
+        console.log(`Connected to ${port}`);
         if (options.shell) {
           console.log(colorName(`Type Ctrl-D to exit`));
           bind(serial, [
@@ -266,7 +266,7 @@ program
       if (err) {
         console.error(err);
       } else {
-        console.log(`connected to ${port}`);
+        console.log(`Connected to ${port}`);
         await erase(serial);
         console.log("erased.");
       }
@@ -321,7 +321,7 @@ program
       if (err) {
         console.error(err);
       } else {
-        console.log(`connected to ${port}`);
+        console.log(`Connected to ${port}`);
         const bs = new BufferedSerial(serial);
         process.stdout.write(colors.grey("copying "));
         await put(bs, srcPath, dest, fileSize, () => {
@@ -363,7 +363,7 @@ program
         if (err) {
           console.error(err);
         } else {
-          console.log(`connected to ${port}`);
+          console.log(`Connected to ${port}`);
           const bs = new BufferedSerial(serial);
           const fun = `
           function (fn) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kaluma/cli",
   "description": "Kaluma CLI (Command Line Interface)",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Minkyu Lee <niklaus.lee@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some small suggested tweaks:

* Change Ctrl-Z to Ctrl-D for more standardized usage (see sqlite3, MySQL, most shells, etc.)
* Change to "-v, --version" instead of "-V, --version" (matches `node`, `npm`, and others)
* Uppercase the initial "C" when connecting
* Bump version number to 1.4.1